### PR TITLE
input variable allows bastion to be created in private subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@ In a clean directory, create a `main.tf` file that looks like:
 
 ```hcl
 module "bastion" {
-  source            = "git@github.com:byu-oit/terraform-aws-bastion.git?ref=v1.0.2"
+  source            = "git@github.com:byu-oit/terraform-aws-bastion.git?ref=v1.0.3"
   env               = "prd"
   vpc_vpn_to_campus = true
   netid             = "mynetid"
   public_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwWVPlHpRiXGBmB/VG6PUeJ/Ev+Y39n5PBI4DW3ZMDT1g32nEUjzKtxK6KwVzYFQBhReMO2ry4uSTiNIzuOtHk/OCfcdPc8wbW3RlHBgbqs6p7DfYRJAXJCnWEjovijaVY0lyL4+7/YuprZwBaA2NfUIRN8UwVxZck3ULMnCK6BKog0UAE9NQZ9Z0vAtgLYPo9eVJEuGrxEszN29X+4Fl6u3T8x0XQ9EoMWU4YNwKfzBIof3th9Cbv4+FlEKpOFYuCc5vB2NPotalN8phEUqnvtsDkmCLAop6+MrUlnNNYIzmh2RLeqDF+M/ZnX8xb+V/mT9vARVcdcYCxKYeyXLvT example"
   #ingress_cidrs     = ["128.187.112.21/32"] # optional (defaults to BYU Campus)
+  #subnet_type       = private # optional (defaults to public)
 }
 
 output "connect" {
@@ -68,7 +69,14 @@ The bastion is really intended to be ephemeral (spin it up, use it, tear it down
 | vpc_vpn_to_campus | Set to true if the bastion needs to be in the VPC that has VPN access to campus | false |
 | netid | Your Net ID (for naming the bastion) | |
 | public_key | Public SSH Key (e.g. \"ssh-rsa AA....Qw== comment\"). | |
-| ingress_cidrs | IP Address Ranges that should have access to the bastion. | ["128.187.0.0/16"] |
+| ingress_cidrs | IP Address Ranges that should have access to the bastion. | ["128.187.0.0/16", "10.0.0.0/8"] |
+| subnet_type | Which subnet type sould the bastion launch in? (e.g. public, private, data) | "public" |
+
+Notes on `subnet_type`:
+
+* `public` is useful for troubleshooting when your target is inside AWS. But the public subnets don't have routing to the VPN, so you won't be able to reach back to campus from the bastion.
+* `private` is useful for troubleshooting connections back to campus across the VPN. But you won't be able to reach the bastion publicly from your workstation.
+* If you need a `private` bastion, you'll either need to reach it across the VPN (i.e. be running the dc vpn on your workstation), or spin up a second "public" bastion to go through.
 
 ## Output
 | Name | Description |

--- a/examples/command_line/create_bastion.sh
+++ b/examples/command_line/create_bastion.sh
@@ -4,5 +4,9 @@
 # to accept the default CIDR (BYU Campus)
 terraform apply -var "env=prd" -var "vpc_vpn_to_campus=true" -var "netid=mynetid" -var "public_key=$(cat ~/.ssh/id_rsa.pub)"
 
-# to specify a specific CIDR (e.g. your ip address)
+# to use a specific CIDR (e.g. your ip address)
 terraform apply -var "env=prd" -var "vpc_vpn_to_campus=true" -var "netid=mynetid" -var "public_key=$(cat ~/.ssh/id_rsa.pub)" -var "ingress_cidrs=[\"128.187.112.21/32\"]"
+
+# to use a specific subnet type (e.g. public, private, data)
+terraform apply -var "env=prd" -var "vpc_vpn_to_campus=true" -var "netid=mynetid" -var "public_key=$(cat ~/.ssh/id_rsa.pub)" -var "subnet_type=private"
+

--- a/examples/module/example.tf
+++ b/examples/module/example.tf
@@ -1,10 +1,11 @@
 module "bastion" {
-	source            = "git@github.com:byu-oit/terraform-aws-bastion.git?ref=v1.0.2"
+	source            = "git@github.com:byu-oit/terraform-aws-bastion.git?ref=v1.0.3"
   env               = "prd"
   vpc_vpn_to_campus = true
   netid             = "mynetid"
   public_key        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwWVPlHpRiXGBmB/VG6PUeJ/Ev+Y39n5PBI4DW3ZMDT1g32nEUjzKtxK6KwVzYFQBhReMO2ry4uSTiNIzuOtHk/OCfcdPc8wbW3RlHBgbqs6p7DfYRJAXJCnWEjovijaVY0lyL4+7/YuprZwBaA2NfUIRN8UwVxZck3ULMnCK6BKog0UAE9NQZ9Z0vAtgLYPo9eVJEuGrxEszN29X+4Fl6u3T8x0XQ9EoMWU4YNwKfzBIof3th9Cbv4+FlEKpOFYuCc5vB2NPotalN8phEUqnvtsDkmCLAop6+MrUlnNNYIzmh2RLeqDF+M/ZnX8xb+V/mT9vARVcdcYCxKYeyXLvT example"
 	#ingress_cidrs     = ["128.187.112.21/32"] # optional (defaults to BYU Campus)
+	#subnet_type       = "private" # optional (defaults to public) (if anything other than "public", you'll need to use another bastion, vpn, etc. to ssh in.)
 }
 
 output "connect" {

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ resource "aws_instance" "bastion" {
   ami                    = "ami-0c5204531f799e0c6"
   instance_type          = "t2.micro"
   key_name               = aws_key_pair.key.key_name
-  subnet_id              = module.acs.public_subnet_ids[0]
+  subnet_id              = module.acs["${var.subnet_type}_subnet_ids"][0]
   vpc_security_group_ids = [aws_security_group.sg.id]
 
   tags = {

--- a/output.tf
+++ b/output.tf
@@ -1,15 +1,15 @@
 output "connect" {
-  value = "ssh ec2-user@${aws_instance.bastion.public_ip}"
+  value = "ssh ec2-user@${length(aws_instance.bastion.public_ip) > 0 ? aws_instance.bastion.public_ip : aws_instance.bastion.private_ip}"
 }
 
 output "ec2_instance" {
-	value = aws_instance.bastion
+  value = aws_instance.bastion
 }
 
 output "security_group" {
-	value = aws_security_group.sg
+  value = aws_security_group.sg
 }
 
 output "key_pair" {
-	value = aws_key_pair.key
+  value = aws_key_pair.key
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,13 @@ variable "public_key" {
 }
 
 variable "ingress_cidrs" {
-	type = list(string)
-	default = ["128.187.0.0/16"]
-	description = "IP Address Ranges that should have access to the bastion."
+  type        = list(string)
+  default     = ["128.187.0.0/16", "10.0.0.0/8"]
+  description = "IP Address Ranges that should have access to the bastion."
+}
+
+variable "subnet_type" {
+  type        = string
+  default     = "public"
+  description = "Which subnet type should the bastion launch in? (e.g. public, private, data)"
 }


### PR DESCRIPTION
Sublic subnets don't have routing back to campus. For troubleshooting connections back to campus, we need to be able to spin up bastions in private subnets.