### PR TITLE
Add required ttl field

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ provider "aws" {
 }
 
 module "bastion" {
-  source            = "github.com/byu-oit/terraform-aws-bastion.git?ref=v2.2.0"
+  source            = "github.com/byu-oit/terraform-aws-bastion.git?ref=v2.2.1"
   env               = "prd"
   vpc_vpn_to_campus = true
   netid             = "mynetid"

--- a/main.tf
+++ b/main.tf
@@ -67,5 +67,6 @@ resource "aws_route53_record" "a_record" {
   name    = local.app_domain_name
   type    = "A"
   zone_id = local.app_zone_id
+  ttl     = 60
   records = [length(aws_instance.bastion.public_ip) > 0 ? aws_instance.bastion.public_ip : aws_instance.bastion.private_ip]
 }


### PR DESCRIPTION
Forgot that ttl was required for non-alias records. I set the ttl to 60 because that is [the ttl for alias records](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record#alias-record).